### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-deploy-pages.yml
+++ b/.github/workflows/build-deploy-pages.yml
@@ -7,6 +7,9 @@ on:
     pull_request:
         branches: ['master']
 
+permissions:
+    contents: read
+
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/afarago/blpy.attilafarago.hu/security/code-scanning/4](https://github.com/afarago/blpy.attilafarago.hu/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the current workflow, the `contents: read` permission is sufficient for the `build` job, as it only checks out the repository and uploads artifacts. 

The `permissions` block should be added at the root level of the workflow to apply to all jobs, or specifically to the `build` job if other jobs in the workflow require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
